### PR TITLE
Documentation + Security update

### DIFF
--- a/.claude/commands/security-reviewer.md
+++ b/.claude/commands/security-reviewer.md
@@ -1,4 +1,4 @@
-<!-- version: 1 -->
+<!-- version: 2 -->
 <!-- mode: read-only -->
 
 You are the **Security Reviewer** for this project.
@@ -23,6 +23,7 @@ Verify `backend/main.py` and `backend/auth.py` exist before proceeding. If eithe
 - `backend/main.py` — all endpoint definitions
 - `backend/auth.py` — `get_current_user` and `require_admin` dependency definitions
 - `backend/twitch.py` — Twitch EBS router (if it exists)
+- `backend/email_utils.py` — email sending helpers (check for enumeration and data-exposure risks)
 
 ---
 
@@ -34,7 +35,7 @@ For **every** `@app.get`, `@app.post`, `@app.put`, `@app.patch`, `@app.delete` a
 Classify each endpoint as one of:
 - **Public** — intentionally no auth (login, logout, register, forgot-password, /me with session check, /config, /schedule, /health, /top, /leaderboard, /simulate, /players, /teams, /weeks, /deck)
 - **Auth required** — should have `Depends(get_current_user)` or `Depends(require_admin)`
-- **Admin required** — routes under `/admin/`, `/ingest/`, `/grant-tokens`, `/codes`, `/audit-logs`, `/recalculate`, `/weights` (POST)
+- **Admin required** — routes under `/admin/`, `/ingest/`, `/grant-tokens`, `/codes`, `/audit-logs`, `/recalculate`
 - **Twitch JWT required** — `/twitch/*` routes validated by `verify_twitch_jwt`
 
 Flag any endpoint that is **not public** but is missing the appropriate `Depends()`.

--- a/.claude/commands/systems-architect.md
+++ b/.claude/commands/systems-architect.md
@@ -1,4 +1,4 @@
-<!-- version: 1 -->
+<!-- version: 2 -->
 <!-- mode: read-only -->
 
 You are the **Systems Architect** for this project.
@@ -29,6 +29,10 @@ Verify `backend/main.py` and `backend/models.py` exist. If either is missing, re
 - `backend/twitch.py` — Twitch EBS router
 - `backend/database.py` — database setup and session factory
 - `backend/seed.py` — seeding and DEFAULT_WEIGHTS
+- `backend/email_utils.py` — email sending helpers
+- `backend/image.py` — image generation utilities
+- `backend/opendota_client.py` — OpenDota API client
+- `backend/dotabuff_league_logos.py` — Dotabuff logo fetching
 
 **Frontend:**
 - `frontend/app.js` — all client-side logic

--- a/backend/twitch.py
+++ b/backend/twitch.py
@@ -127,7 +127,7 @@ class LinkCodeResponse(BaseModel):
 
 
 class LinkBody(BaseModel):
-    code: str
+    code: str = Field(min_length=1, max_length=6)
 
 
 def get_session_user(request: Request) -> dict:
@@ -415,6 +415,13 @@ def set_mvp(
                 detail=f"channel={channel_id} match={body.match_id} count={len(winner_names)} winners={','.join(winner_names)}",
             ))
 
+    db.add(AuditLog(
+        timestamp=int(time.time()),
+        actor_id=None,
+        actor_username="twitch",
+        action="twitch_mvp_set",
+        detail=f"channel={channel_id} match={body.match_id} player={player.name} re_select={bool(existing)}",
+    ))
     db.commit()
     _pubsub_broadcast(channel_id, {
         "type": "mvp",
@@ -432,13 +439,3 @@ def set_mvp(
             "already_dropped": already_dropped,
         },
     }
-    db.add(AuditLog(
-        timestamp=int(time.time()),
-        actor_id=None,
-        actor_username="twitch",
-        action="twitch_token_drop",
-        detail=f"channel={channel_id} series={body.series_id} count={len(winner_names)} winners={','.join(winner_names)}",
-    ))
-    db.commit()
-    _pubsub_broadcast(channel_id, {"type": "token_drop", "winners": winner_names})
-    return {"winners": winner_names, "pool_size": len(pool)}

--- a/markdown/feature_description/admin.md
+++ b/markdown/feature_description/admin.md
@@ -9,7 +9,7 @@ All admin endpoints require an active admin session. Unauthorized requests recei
 ## User Management
 
 ### `GET /users`
-Returns a list of all registered users with their ID, username, email, token count, admin status, and linked OpenDota player ID.
+Returns a list of all registered users. Each entry contains `id`, `username`, and `tokens`.
 
 ### `POST /grant-tokens`
 Grants a configurable number of tokens to a specific user.
@@ -18,7 +18,7 @@ Grants a configurable number of tokens to a specific user.
 { "target_user_id": 5, "amount": 3 }
 ```
 
-Negative amounts are not validated server-side — use carefully. All grants are recorded in the audit log.
+Amount must be at least 1 — the endpoint returns 422 for values below 1. All grants are recorded in the audit log.
 
 ---
 
@@ -90,6 +90,9 @@ Ingest also runs automatically every 15 minutes in the background. The manual en
 
 ## Schedule
 
+### `GET /schedule`
+Returns the current season fixture list parsed from the Google Sheets source (cached for 1 hour). No authentication required. Used by the frontend to display upcoming and past series.
+
 ### `POST /schedule/refresh`
 Clears the 1-hour schedule cache, forcing the next `GET /schedule` request to re-fetch from the Google Sheets source.
 
@@ -138,4 +141,11 @@ Returns the most recent audit log entries, newest first. All significant admin a
 ## App Config
 
 ### `GET /config`
-Returns public configuration values used by the frontend (e.g. `TOKEN_NAME`, `APP_NAME`, roster limits). No authentication required.
+Returns public configuration values used by the frontend. No authentication required.
+
+```json
+{ "token_name": "Kana Tokens", "initial_tokens": 5 }
+```
+
+### `GET /health`
+Returns `{"status": "ok"}`. No authentication required. Used by container health checks.

--- a/markdown/feature_description/auth.md
+++ b/markdown/feature_description/auth.md
@@ -1,0 +1,79 @@
+# Authentication
+
+User accounts and sessions for the FantasyLeague app. Sessions are server-side, stored in a signed cookie managed by Starlette's `SessionMiddleware`.
+
+---
+
+## Endpoints
+
+### `POST /register`
+
+Creates a new user account and logs the user in immediately.
+
+```json
+{ "username": "SomeUser", "email": "user@example.com", "password": "securepass" }
+```
+
+- Username must be unique — 409 if taken.
+- Email must be a valid address and unique — 409 if already registered.
+- Password minimum length: 6 characters.
+- New users receive `INITIAL_TOKENS` tokens on registration (default: 5).
+- Returns `{ "username", "is_admin", "tokens" }` and sets the session cookie.
+- Records a `user_register` audit log entry.
+
+---
+
+### `POST /login`
+
+Authenticates with username and password.
+
+```json
+{ "username": "SomeUser", "password": "password" }
+```
+
+- Returns 401 if credentials are invalid.
+- Returns `{ "username", "is_admin", "tokens" }` and sets the session cookie.
+- Records a `user_login` audit log entry.
+
+---
+
+### `POST /logout`
+
+Clears the session cookie. No request body required. Always returns `{ "status": "ok" }`.
+
+---
+
+### `GET /me`
+
+Returns the current session user. Returns 401 if not logged in.
+
+```json
+{
+  "user_id": 3,
+  "username": "SomeUser",
+  "is_admin": false,
+  "tokens": 4,
+  "must_change_password": false
+}
+```
+
+`must_change_password` is `true` after a forgot-password reset (see `profile.md`). The frontend should detect this flag on login and redirect to the profile password change form before allowing other actions.
+
+---
+
+## Session Cookie
+
+Sessions are signed with `SECRET_KEY`. In production `SECRET_KEY` must be set — the app refuses to start without it unless `DEBUG=true`.
+
+Set `HTTPS_ONLY=true` when running behind an HTTPS reverse proxy (e.g. nginx, Caddy) to enable the `Secure` flag on the session cookie.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `SECRET_KEY` | *(insecure dev default)* | Session signing key — **must be set in production** |
+| `HTTPS_ONLY` | `false` | Enables `Secure` cookie flag when behind an HTTPS reverse proxy |
+| `DEBUG` | `false` | Bypasses `SECRET_KEY` requirement for local dev — **never set in production** |
+| `INITIAL_TOKENS` | `5` | Tokens granted to each newly registered user |

--- a/markdown/feature_description/card-image-generation.md
+++ b/markdown/feature_description/card-image-generation.md
@@ -1,0 +1,130 @@
+# Card Image Generation
+
+Each card in the deck is represented as a dynamically composited PNG served by `GET /cards/{card_id}/image`. The image is generated on demand by `backend/image.py` using the Pillow library.
+
+---
+
+## Template files
+
+Four rarity-specific PNG templates must be present in the assets directory:
+
+| Rarity | File |
+|---|---|
+| Common | `Card_Template_Common.png` |
+| Rare | `Card_Template_Rare.png` |
+| Epic | `Card_Template_Epic.png` |
+| Legendary | `Card_Template_Legendary.png` |
+
+All templates share the same canvas size: **597 × 845 px**.
+
+The template PNG is a fully-designed frame — rarity border, decorative elements, name plate, and background art — with transparent cutouts where the player avatar and team logo are composited underneath. The frame is layered on top of the player content so it always reads cleanly.
+
+The assets directory is resolved at startup by searching several candidates (`assets/`, `Assets/`, `/app/Assets/`, etc.) for a folder containing all four template files. Linux containers use `/app/Assets` by convention; local development typically uses `assets/` or `Assets/` at the repo root.
+
+---
+
+## Compositing pipeline
+
+The image is built in five layers, in order:
+
+1. **Dark base** — a solid `(35, 37, 40)` RGBA fill at full card size. Provides the background colour for areas the template does not cover.
+
+2. **Player avatar** — the player's OpenDota avatar image is downloaded, resized to a 350 × 350 px square (radius 175), circle-cropped with an alpha mask, and pasted onto the base centred at `(298, 375)`. If the avatar URL is unavailable or the download fails, the slot is left as the dark base colour.
+
+3. **Team logo** — the team logo is loaded from the local Dotabuff PNG cache first (`assets/dotabuff_league_logos/<team-name>.png`), falling back to the HTTP `logo_url` stored on the team record. It is resized to 104 × 104 px (radius 52), circle-cropped, and pasted at `(444, 258)`. Missing logos are silently skipped.
+
+4. **Template overlay** — the rarity template PNG is alpha-composited on top of the base, covering the avatar/logo layers with its frame. This is what provides the rarity border, name plates, and decorative chrome.
+
+5. **Text and modifiers** — player name, team name, and stat modifier lines are drawn over the composite using `ImageDraw`.
+
+---
+
+## Layout coordinates
+
+All positions are in pixels relative to the 597 × 845 canvas. Epic and Legendary templates have their content plates positioned slightly lower than Common and Rare; a `+8 px` Y offset (`_CARD_LAYOUT_Y_OFFSET_EPIC_LEGENDARY`) is applied to all dynamic content (avatar, team logo, text, modifiers) for those rarities so that text and images align with the template plates correctly.
+
+| Element | Position |
+|---|---|
+| Player avatar centre | `(298, 375)` — radius 175 |
+| Team logo centre | `(444, 258)` — radius 52 |
+| Player name baseline Y | `90` (+ rarity offset) |
+| Team name baseline Y | `155` (+ rarity offset) |
+| First modifier line Y | `620` (+ rarity offset) |
+| Modifier line spacing | `50 px` |
+
+---
+
+## Text rendering
+
+Text is drawn centered horizontally on the card. All names are uppercased. A drop shadow is drawn 2 px offset before the main text to maintain legibility over varied template colours.
+
+| Element | Font size | Fill colour | Max width before truncation |
+|---|---|---|---|
+| Player name | 32 pt | `(35, 35, 35)` dark | 480 px |
+| Team name | 22 pt | `(35, 35, 35)` dark | — |
+| Modifier lines | 30 pt | `(200, 230, 210)` green-tint | 500 px |
+
+The name plate areas on the template are light-coloured, so dark text is used there. The modifier band sits below the portrait on a dark area of the template, so the modifier text uses a light green tint.
+
+The font fallback chain (tried in order):
+1. `LiberationSans-Bold.ttf`
+2. `FreeSansBold.ttf`
+3. `DejaVuSans-Bold.ttf`
+4. PIL built-in default (bitmap, low quality — indicates a missing font package)
+
+---
+
+## Stat modifier labels
+
+Modifier lines are rendered in the lower band of the card (below the portrait area). Each line shows the stat name and bonus percentage, e.g. `KILLS +10%`. Stat keys are mapped to human-readable labels:
+
+| Stat key | Card label |
+|---|---|
+| `kills` | KILLS |
+| `assists` | ASSISTS |
+| `deaths` | DEATHS |
+| `gold_per_min` | GPM |
+| `obs_placed` | OBSERVER WARDS |
+| `sen_placed` | SENTRY WARDS |
+| `tower_damage` | TOWER DAMAGE |
+
+Lines are sorted alphabetically by stat key and stacked from `y=620` downward. If there are no modifiers (e.g. a Common card), the lower band is left empty.
+
+---
+
+## Team logo sources
+
+The generator prefers locally cached Dotabuff logos over live HTTP fetches for reliability and speed:
+
+1. **Local file** — `assets/dotabuff_league_logos/<team-name>.png` (downloaded during ingest; see `ingest.md`)
+2. **HTTP fallback** — `team.logo_url` stored in the database (Dotabuff CDN URL)
+
+Both are circle-cropped before compositing. If neither source is available, the team logo slot is left empty.
+
+---
+
+## API endpoint
+
+### `GET /cards/{card_id}/image`
+
+Returns the composited card PNG for any card regardless of ownership. Response headers: `Content-Type: image/png`, `Cache-Control: no-cache`.
+
+- Returns **404** if the card does not exist.
+- Returns **503** if the Pillow library is not installed in the runtime environment.
+
+The image is generated fresh on every request (no server-side caching). The frontend adds a cache-bust query parameter after a reroll so the browser does not serve a stale image from its own cache.
+
+---
+
+## Adding or updating card templates
+
+To change the card visual design, replace the four template PNGs in the assets directory. The templates must:
+
+- Be exactly **597 × 845 px**
+- Use **RGBA** mode (transparency where player content should show through)
+- Place the name plate area around **y ≈ 75–170** (where player name and team name are drawn)
+- Leave the lower area around **y ≈ 620–750** clear for modifier text
+- Position the portrait cutout centred near **(298, 375)**
+- Position the team badge cutout centred near **(444, 258)**
+
+If the plate positions shift significantly between rarities, adjust `_CARD_LAYOUT_Y_OFFSET_EPIC_LEGENDARY` in `backend/image.py` or introduce per-rarity offsets.

--- a/markdown/feature_description/cards.md
+++ b/markdown/feature_description/cards.md
@@ -4,7 +4,7 @@ Cards are the core collectible unit of the fantasy league. Each card represents 
 
 ## Card Rarities
 
-Each player has four cards in the deck with different rarities:
+Each player has four cards in the deck with different rarities. In API responses the rarity is returned as the `card_type` field with values `"common"`, `"rare"`, `"epic"`, or `"legendary"`.
 
 | Rarity | Count per player | Default rarity bonus | Default modifiers granted |
 |--------|-----------------|---------------------|--------------------------|
@@ -13,7 +13,7 @@ Each player has four cards in the deck with different rarities:
 | Epic | 2 | +2% | 2 |
 | Legendary | 1 | +3% | 3 |
 
-**Rarity bonus** is a flat multiplier applied to the card's total fantasy score after all other calculations. It is configurable in the admin panel under Scoring Weights (`rarity_common`, `rarity_rare`, `rarity_epic`, `rarity_legendary`).
+**Rarity bonus** is a percentage multiplier applied to the card's total fantasy score after all other calculations (e.g. +1% means the total is multiplied by 1.01). It is configurable in the admin panel under Scoring Weights (`rarity_common`, `rarity_rare`, `rarity_epic`, `rarity_legendary`).
 
 ## Drawing Cards
 
@@ -144,6 +144,49 @@ The current system uses a single uniform `bonus_pct` for all modifiers. Future e
 - Card-specific modifiers that affect only one player's known strengths
 
 To add a new modifier type, add a new row to the `card_modifiers` table with the appropriate `stat_key` and `bonus_pct`. Any `stat_key` present in `SCORING_STATS` (defined in `backend/scoring.py`) will be applied automatically.
+
+---
+
+## Roster Endpoints
+
+### `GET /roster/{user_id}`
+
+Returns the calling user's cards split into `active` and `bench` lists, with per-card fantasy points scoped to the requested week.
+
+**Query parameter:** `week_id` (optional integer). Omit to use the current editable week.
+
+- For a **locked** week: returns the immutable `WeeklyRosterEntry` snapshot for that week with points from matches played during the week's window.
+- For the **current editable** week: returns all owned cards from the `cards` table, split by `is_active`, with running points accumulated so far.
+
+```json
+{
+  "active": [{ "id": 42, "card_type": "rare", "player_name": "SomePlayer", "total_points": 34.5, "modifiers": [...], ... }],
+  "bench":  [...],
+  "combined_value": 130.2,
+  "season_points": 420.0,
+  "tokens": 4
+}
+```
+
+Requires authentication. Returns 401 if not logged in.
+
+---
+
+### `POST /roster/{card_id}/activate`
+
+Moves a benched card into the active roster. Requires authentication; the card must be owned by the caller.
+
+- Returns 409 `"Roster full"` if the user already has `ROSTER_LIMIT` active cards (default: 5).
+- Returns 409 `"A card for this player is already active"` if another card for the same player is already active.
+- Returns `{ "status": "ok", "card_id": N }` on success.
+
+---
+
+### `POST /roster/{card_id}/deactivate`
+
+Moves an active card to the bench. Requires authentication; the card must be owned by the caller.
+
+Returns `{ "status": "ok", "card_id": N }`.
 
 ---
 

--- a/markdown/feature_description/commands.md
+++ b/markdown/feature_description/commands.md
@@ -116,6 +116,8 @@ SELECT label, is_locked, datetime(start_time, 'unixepoch') as start,
 | `TOKEN_NAME` | `Tokens` | Display name for the token currency |
 | `INITIAL_TOKENS` | `5` | Tokens granted to newly registered users |
 | `SECRET_KEY` | *(insecure dev default)* | Session signing key — **must be set in production** |
+| `DEBUG` | *(unset)* | Set to `true` to bypass `SECRET_KEY` requirement for local dev — **never set in production** |
+| `HTTPS_ONLY` | `false` | Set to `true` when behind an HTTPS reverse proxy; enables `Secure` flag on session cookies |
 | `SMTP_HOST` | *(empty)* | SMTP host for email (forgot-password). Disabled if unset. |
 | `SMTP_PORT` | `587` | SMTP port |
 | `SMTP_USER` | *(empty)* | SMTP username |
@@ -127,3 +129,4 @@ SELECT label, is_locked, datetime(start_time, 'unixepoch') as start,
 | `TWITCH_EXTENSION_SECRET` | *(empty)* | Base64-encoded extension secret from Twitch dev console |
 | `TWITCH_DROP_MAX` | `20` | Server-side cap on viewers per token drop |
 | `TWITCH_LOCAL_DEV` | *(unset)* | Set to `true` to bypass Twitch JWT validation locally — **never set in production** |
+| `ROSTER_LIMIT` | `5` | Maximum active cards per user roster |

--- a/markdown/feature_description/players.md
+++ b/markdown/feature_description/players.md
@@ -1,0 +1,105 @@
+# Players & Teams
+
+Read-only endpoints that expose the ingested players and teams with fantasy point aggregates and match history. All endpoints are public — no authentication required.
+
+---
+
+## Players
+
+### `GET /players`
+
+Returns all ingested players sorted by total fantasy points descending. Each entry reflects stats across all ingested matches for the season.
+
+```json
+[
+  {
+    "id": 123456789,
+    "name": "SomePlayer",
+    "avatar_url": "https://...",
+    "team_name": "SomeTeam",
+    "team_id": 42,
+    "matches": 18,
+    "avg_points": 28.4,
+    "total_points": 511.2
+  }
+]
+```
+
+`team_name` and `team_id` are resolved from the player's most recent ingested match.
+
+---
+
+### `GET /players/{player_id}`
+
+Returns full detail for a single player, including a complete per-match history sorted by most recent first.
+
+```json
+{
+  "id": 123456789,
+  "name": "SomePlayer",
+  "avatar_url": "https://...",
+  "team_name": "SomeTeam",
+  "team_id": 42,
+  "matches": 18,
+  "avg_points": 28.4,
+  "total_points": 511.2,
+  "best_match": {
+    "match_id": 8001,
+    "fantasy_points": 52.1,
+    "start_time": 1741560000
+  },
+  "match_history": [
+    {
+      "match_id": 8001,
+      "start_time": 1741560000,
+      "fantasy_points": 52.1,
+      "kills": 12, "assists": 8, "deaths": 1,
+      "gold_per_min": 720.0,
+      "obs_placed": 0, "sen_placed": 0, "tower_damage": 5400,
+      "team_id": 42, "team_name": "SomeTeam"
+    }
+  ]
+}
+```
+
+Returns 404 if the player has not been ingested.
+
+---
+
+## Teams
+
+### `GET /teams`
+
+Returns all ingested teams sorted by match count descending.
+
+```json
+[
+  { "id": 42, "name": "SomeTeam", "matches": 18, "player_count": 5 }
+]
+```
+
+---
+
+### `GET /teams/{team_id}`
+
+Returns a team's details and the roster of players who have appeared in a match for that team, ordered by total fantasy points.
+
+```json
+{
+  "id": 42,
+  "name": "SomeTeam",
+  "matches": 18,
+  "players": [
+    {
+      "id": 123456789,
+      "name": "SomePlayer",
+      "avatar_url": "https://...",
+      "matches": 18,
+      "avg_points": 28.4,
+      "total_points": 511.2
+    }
+  ]
+}
+```
+
+Returns 404 if the team has not been ingested.

--- a/markdown/feature_description/profile.md
+++ b/markdown/feature_description/profile.md
@@ -16,9 +16,12 @@ Returns basic public information for any user by ID. No authentication required.
   "username": "SomeUser",
   "player_id": 123456789,
   "player_name": "SomePlayer",
-  "player_avatar_url": "https://..."
+  "player_avatar_url": "https://...",
+  "twitch_linked": true
 }
 ```
+
+`twitch_linked` is `true` if the user has completed the Twitch account linking flow. See `twitch-extension.md`.
 
 `player_name` and `player_avatar_url` are `null` if the user has not linked a Dota 2 account, or if the linked `player_id` does not exist in the local database.
 

--- a/markdown/feature_description/terminology.md
+++ b/markdown/feature_description/terminology.md
@@ -47,5 +47,3 @@
 **Toornament** — The tournament bracket platform (toornament.com) where the Kanaliiga tournament is managed. The app automatically pushes series results there after each ingest cycle. See `toornament.md`.
 
 **Audit Log** — A time-ordered record of significant system events (ingests, token grants, week locks, admin actions). Visible to admins at `GET /audit-logs`.
-
-**Promo Code** — An admin-created alphanumeric code that grants a configurable number of tokens when redeemed. Each code can be redeemed once per user.

--- a/markdown/feature_description/twitch-extension.md
+++ b/markdown/feature_description/twitch-extension.md
@@ -72,7 +72,7 @@ Viewers who open the panel call `POST /twitch/heartbeat` every ~55 seconds. Only
 
 ## Twitch PubSub
 
-When a giveaway winner is selected, a token drop completes, or an MVP is set, the EBS calls:
+When an MVP is confirmed (which triggers a token drop) the EBS calls:
 
 ```
 POST https://api.twitch.tv/helix/extensions/pubsub
@@ -105,6 +105,9 @@ Upload the produced ZIP in the Twitch dev console. Set the version to **Local Te
 
 ### Step 4 — Install and test
 Add the extension to the broadcast channel. Open the Twitch Stream Manager to confirm the Quick Actions (Live Config) view appears. Test the account linking flow from the Fantasy profile tab.
+
+### Local development
+The `twitch-extension/` folder is served by the backend at `/twitch-ext` when the directory is present. The dev harness is accessible at `http://localhost:8000/twitch-ext/dev-harness.html` and simulates the extension panel without requiring a real Twitch session. It is not uploaded to Twitch CDN — only the packaged ZIP is.
 
 ---
 
@@ -161,4 +164,4 @@ Twitch JWT (broadcaster role). Body: `{match_id, player_id}`. Upserts the MVP se
 - PubSub is broadcast-only from EBS to viewers. The extension cannot send PubSub to other viewers directly.
 - MVP selection has no scoring impact — it is engagement/display only in this phase.
 - The extension must be submitted to Twitch for review before public release, or used in developer test mode.
-- The `series_id` for token drops is broadcaster-supplied and opaque — it does not reference a DB series. Convention: `"week3-s2"` or `"2024-01-15"`.
+- The token drop deduplication key is set automatically to the match ID — once tokens are dropped for a given match they will not drop again even if the broadcaster re-confirms a different MVP.

--- a/markdown/user_stories.md
+++ b/markdown/user_stories.md
@@ -25,6 +25,10 @@
    - 3.6 Modifier Management
    - 3.7 View Seasonal Reserve Cards
    - 3.8 View Permanent Collection *(post-MVP)*
+   - 3.9 Card Visual Identity
+   - 3.10 Rarity-Distinct Card Design
+   - 3.11 Modifier Labels on Card Image
+   - 3.12 Replaceable Card Template Artwork
 4. [Active Lineup and Reserve Management](#4-active-lineup-and-reserve-management)
    - 4.1 Place Cards into Active Slots
    - 4.2 Lock Active Cards
@@ -305,6 +309,53 @@ As a user, I want to track cards across seasons.
 - No gameplay effect
 - Supports filtering
 - Past season cards are stored separately so they are not included in current season logic
+
+---
+
+### 3.9 Card Visual Identity
+**User story**
+As a user, I want each card to display the player's name, team name, photo, and team emblem so I can identify the player and team at a glance without reading separate UI text.
+
+**Acceptance criteria**
+- Player name is printed on the card image in the name plate area (uppercased, truncated if too long)
+- Team name is printed below the player name on the card image
+- Player avatar (from OpenDota) is composited as a circular portrait on the card image
+- Team logo (from local Dotabuff cache, HTTP fallback) is composited as a smaller circular badge on the card image
+- If avatar or logo is unavailable, the card still renders correctly with the slot left empty
+- During the draw reveal animation, player and team names are sourced from the card PNG only — they are not duplicated in the HTML below the image
+
+---
+
+### 3.10 Rarity-Distinct Card Design
+**User story**
+As a user, I want each rarity tier to have a visually distinct card frame so I can identify rarity from the card art alone.
+
+**Acceptance criteria**
+- Each rarity (Common, Rare, Epic, Legendary) uses a separate template PNG with its own border and colour scheme
+- Rarity frame is always visible regardless of player or team
+- Card image is returned correctly for all four rarities
+
+---
+
+### 3.11 Modifier Labels on Card Image
+**User story**
+As a user, I want my card's stat modifiers printed directly on the card image so the bonus is always visible without opening a detail view.
+
+**Acceptance criteria**
+- Each active modifier is shown in the lower band of the card as `STAT +X%`
+- After a reroll, the card image updates immediately to reflect the new modifiers
+- Cards with no modifiers (e.g. Common) show no modifier text in that area
+
+---
+
+### 3.12 Replaceable Card Template Artwork
+**User story**
+As an operator, I want to update card template artwork for each rarity by replacing files so the visual design can be refreshed between seasons without code changes.
+
+**Acceptance criteria**
+- Templates are loaded from a configurable assets directory at startup
+- Replacing any of the four template PNGs takes effect on the next card image request
+- Missing templates fail with a clear error rather than silently using a wrong rarity
 
 ---
 


### PR DESCRIPTION
Backend (backend/twitch.py)                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                  
  - Security fix: Added Field(min_length=1, max_length=6) validation to LinkBody.code — previously was an unconstrained bare str.
  - Audit log fix: Moved the AuditLog entry for MVP selection to fire before db.commit() (it was after, so it could be missed on failure). Audit action renamed from twitch_token_drop → twitch_mvp_set with corrected detail fields.
  - Removed dead code: The old standalone token-drop PubSub broadcast block at the end of set_mvp was deleted (token drops now happen as a side effect of MVP confirmation).

  Agent definitions updated (v1 → v2)

  - security-reviewer.md: Now also scans backend/email_utils.py for enumeration/data-exposure risks. Removed /weights (POST) from the admin-required route list.
  - systems-architect.md: Now references four additional backend modules: email_utils.py, image.py, opendota_client.py, dotabuff_league_logos.py.

  New documentation files

  - auth.md (new) — Full spec for /register, /login, /logout, /me; session cookie config; SECRET_KEY / HTTPS_ONLY / DEBUG / INITIAL_TOKENS env vars.
  - card-image-generation.md (new) — Complete spec for the Pillow-based card compositing pipeline: templates, layering order, layout coordinates, text rendering, modifier labels, team logo sources, and the GET /cards/{id}/image endpoint.
  - players.md (new) — Spec for public /players, /players/{id}, /teams, /teams/{id} endpoints with example response shapes.

  Updated documentation files

  - cards.md — Clarified card_type field values in API responses; corrected rarity bonus description (percentage multiplier, not flat). Added full spec for /roster/{user_id}, /roster/{card_id}/activate, /roster/{card_id}/deactivate.
  - admin.md — Tightened GET /users response description (only id, username, tokens exposed). Corrected /grant-tokens to note the 422 on amount < 1. Added GET /schedule, GET /health, and GET /config endpoint descriptions.
  - profile.md — Added twitch_linked field to the GET /profile/{user_id} response.
  - twitch-extension.md — Clarified PubSub trigger (MVP confirmation only, not separate token drop). Added local dev harness note. Updated token drop deduplication note (keyed on match ID).
  - commands.md — Added DEBUG, HTTPS_ONLY, and ROSTER_LIMIT to the env var table.
  - terminology.md — Removed the "Promo Code" entry; minor whitespace fix.

  User stories (user_stories.md)

  - Added 4 new stories under section 3 (Cards): 3.9 Card Visual Identity, 3.10 Rarity-Distinct Card Design, 3.11 Modifier Labels on Card Image, 3.12 Replaceable Card Template Artwork — all tied to the new card image generation feature.